### PR TITLE
Detect FR2(gc64)

### DIFF
--- a/cc/bytecode.lua
+++ b/cc/bytecode.lua
@@ -1280,6 +1280,7 @@ Dump = {
     BE     = 0x01;
     STRIP  = 0x02;
     FFI    = 0x04;
+    FR2    = 0x08;
     DEBUG  = false;
 }
 Dump.__index = {}
@@ -1287,7 +1288,7 @@ function Dump.new(main, name)
     local self =  setmetatable({
         main  = main;
         name  = name;
-        flags = band(main.flags, Dump.FFI);
+        flags = band(main.flags, bor(Dump.FFI, Dump.FR2));
     }, Dump)
     return self
 end

--- a/cc/vr4300/decode_mips.lua
+++ b/cc/vr4300/decode_mips.lua
@@ -59,6 +59,22 @@ MipsDecoder = {
     REG_LO = 0,
     REG_HI = 1,
 }
+do
+    local ljbc = require "jit.bc"
+    local function f(x) end
+    local function g()
+        f(1)
+    end
+    -- LJ_FR2 => 0002    KSHORT   2   1
+    -- !LJ_FR2 => 0002    KSHORT   1   1
+    local ans = {
+        ["0002    KSHORT   2   1\n"] = true,
+        ["0002    KSHORT   1   1\n"] = false,
+    }
+    MipsDecoder.IsFR2 = ans[ljbc.line(g, 2)];
+end
+assert(MipsDecoder.IsFR2 ~= nil)
+MipsDecoder.CallPadding = MipsDecoder.IsFR2 and 1 or 0
 
 ---@type integer gpr
 ---@return integer

--- a/cc/vr4300/vr4300.lua
+++ b/cc/vr4300/vr4300.lua
@@ -102,15 +102,15 @@ function Vr4300:after_trace(bytecode, gpr_cache)
         end
     end
 
-    bytecode:op_move(1, 0)
-    bytecode:op_tget(0, 1, 'S', bytecode:const("run"))
+    bytecode:op_move(1 + MipsDecoder.CallPadding, 0)
+    bytecode:op_tget(0, 1 + MipsDecoder.CallPadding, 'S', bytecode:const("run"))
     bytecode:op_callt(0, 1, 1)
 
     bytecode:close_proto()
 end
 
 function Vr4300:build_trace()
-    local bytecode = bc.Proto.new(nil, 0, 4)
+    local bytecode = bc.Proto.new(MipsDecoder.IsFR2 and bc.Dump.FR2 or 0, 0, 4)
     local gpr_cache = {}
 
     io.write("-- MIPS ASM --\n")


### PR DESCRIPTION
There's a bunch of calls in decode_mips that I didn't touch yet, not sure if you're ok with this approach for the calls or if you'd rather just not support non-gc64